### PR TITLE
These 4 lines enable long LaTeX expressions to be scrollable

### DIFF
--- a/Sources/MarkdownWebView/MarkdownWebView.swift
+++ b/Sources/MarkdownWebView/MarkdownWebView.swift
@@ -110,9 +110,15 @@ import WebKit
                     print("Failed to load resources.")
                     return
                 }
+
+                // Append custom styles
+                let stylesheet: String? = self.parent.customStylesheet.map { str in
+                    defaultStylesheet + str
+                }
+
                 let htmlString = templateString
                     .replacingOccurrences(of: "PLACEHOLDER_SCRIPT", with: script)
-                    .replacingOccurrences(of: "PLACEHOLDER_STYLESHEET", with: self.parent.customStylesheet ?? defaultStylesheet)
+                    .replacingOccurrences(of: "PLACEHOLDER_STYLESHEET", with: stylesheet ?? defaultStylesheet)
                 platformView.loadHTMLString(htmlString, baseURL: nil)
             }
 

--- a/Sources/MarkdownWebView/Resources/stylesheets/default-iOS
+++ b/Sources/MarkdownWebView/Resources/stylesheets/default-iOS
@@ -818,7 +818,7 @@
     }
 }
 
-// Allow overscroll for long KaTex diagrams
+/* Allow overscroll for long KaTex diagrams */
 .katex {
     overflow-x: scroll;
     overflow: auto hidden;

--- a/Sources/MarkdownWebView/Resources/stylesheets/default-iOS
+++ b/Sources/MarkdownWebView/Resources/stylesheets/default-iOS
@@ -200,7 +200,6 @@
 #markdown-rendered h3 {
     font-weight: 600;
     font-size: 1.25em;
-    text-decoration: underline;
 }
 
 #markdown-rendered h4 {

--- a/Sources/MarkdownWebView/Resources/stylesheets/default-iOS
+++ b/Sources/MarkdownWebView/Resources/stylesheets/default-iOS
@@ -200,6 +200,7 @@
 #markdown-rendered h3 {
     font-weight: 600;
     font-size: 1.25em;
+    text-decoration: underline;
 }
 
 #markdown-rendered h4 {
@@ -818,6 +819,7 @@
     }
 }
 
+// Allow overscroll for long KaTex diagrams
 .katex {
     overflow-x: scroll;
     overflow: auto hidden;

--- a/Sources/MarkdownWebView/Resources/stylesheets/default-iOS
+++ b/Sources/MarkdownWebView/Resources/stylesheets/default-iOS
@@ -817,3 +817,8 @@
         /* purposely ignored */
     }
 }
+
+.katex {
+    overflow-x: scroll;
+    overflow: auto hidden;
+}


### PR DESCRIPTION
In iOS, long LaTeX expressions would not be scrollable.
This PR enables long LaTeX expressions to be scrollable